### PR TITLE
Impedindo que usuários passem conjuntos maiores para gera_subconjuntos.

### DIFF
--- a/uteis/combinacoes.py
+++ b/uteis/combinacoes.py
@@ -8,12 +8,16 @@ from typing import (
 
 def gera_subconjuntos(conjunto: Set) -> List[Tuple]:
     """
-    Gera todos os subconjuntos do conjunto informado, no formato
-    de lista com tuplas constituídas pelos elementos de conjunto.
+    Gera subconjuntos do conjunto informado.
 
     :param conjunto:
     :return:
     """
+    limite_len_conjunto: int = 20
+    if len(conjunto) > limite_len_conjunto:
+        raise ValueError('gera_subconjuntos ainda não '
+                         'suporta conjuntos maiores que {}'.format(limite_len_conjunto))
+
     subconjuntos = []
     for i in range(len(conjunto) + 1):
         subconjuntos.extend([comb

--- a/uteis/tests/test_gera_subconjuntos.py
+++ b/uteis/tests/test_gera_subconjuntos.py
@@ -8,8 +8,8 @@ from uteis.combinacoes import gera_subconjuntos
 
 @pytest.mark.parametrize('conjunto_input, resultado_esperado', [
     (set(), [()]),
-    ({100}, [(), (100, )]),
-    ({0, 1}, [(), (0, ), (1, ), (0, 1)])
+    ({100}, [(), (100,)]),
+    ({0, 1}, [(), (0,), (1,), (0, 1)])
 ])
 def test_gera_subconjuntos_retorna_resultado_esperado_de_conjunto_input_tipo_set(conjunto_input,
                                                                                  resultado_esperado):
@@ -17,10 +17,11 @@ def test_gera_subconjuntos_retorna_resultado_esperado_de_conjunto_input_tipo_set
     assert resultado_obtido == resultado_esperado
 
 
-@pytest.mark.parametrize('tamanho_conjunto_input, tamanho_resultado_esperado',[
-    (5, 2**5),
-    (10, 2**10),
-    (13, 2**13),
+@pytest.mark.parametrize('tamanho_conjunto_input, tamanho_resultado_esperado', [
+    (5, 2 ** 5),
+    (10, 2 ** 10),
+    (13, 2 ** 13),
+    (20, 2 ** 20)
 ])
 def test_gera_subconjuntos_retorna_lista_com_tamanho_esperado(tamanho_conjunto_input,
                                                               tamanho_resultado_esperado):
@@ -28,3 +29,17 @@ def test_gera_subconjuntos_retorna_lista_com_tamanho_esperado(tamanho_conjunto_i
     conjunto_teste = {*range(tamanho_conjunto_input)}
     resultado_obtido: List = gera_subconjuntos(conjunto_teste)
     assert len(resultado_obtido) == tamanho_resultado_esperado
+
+
+@pytest.mark.parametrize('tamanho_conjunto_input, tamanho_resultado_esperado', [
+    (21, 2 ** 21),
+    (100, 2**100),
+])
+def test_gera_subconjuntos_lanca_value_error_para_tamanhos_maiores(tamanho_conjunto_input,
+                                                                   tamanho_resultado_esperado):
+    # construindo conjunto de teste com os elementos 0, 1, ..., tamanho_conjunto_input - 1
+    conjunto_teste = {*range(tamanho_conjunto_input)}
+    with pytest.raises(ValueError) as excecao:
+        gera_subconjuntos(conjunto_teste)
+
+    assert 'gera_subconjuntos ainda não suporta conjuntos maiores' in excecao.value.args[0]


### PR DESCRIPTION
Implementação que atende issue #4 